### PR TITLE
fix(cilium): renew Hubble TLS certs via certgen cronJob

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -70,6 +70,12 @@ spec:
         prometheus:
           serviceMonitor:
             enabled: true
+      # NOTE: the "helm" method reuses existing cert secrets verbatim, so it never
+      # renews them and Hubble breaks a year after install. The cronJob method
+      # regenerates them every 4 months via cilium-certgen.
+      tls:
+        auto:
+          method: cronJob
       ui:
         enabled: true
         rollOutPods: true


### PR DESCRIPTION
## Problem

The Cilium 1.20.0 upgrade (#1310) failed and rolled back:

```
Helm upgrade failed for release kube-system/cilium with chart cilium@1.20.0:
timeout waiting for: [Deployment/kube-system/hubble-relay status: 'InProgress']
```

`hubble-relay` was already in `CrashLoopBackOff` before the upgrade:

```
transport: authentication handshake failed: tls: failed to verify certificate:
x509: certificate has expired or is not yet valid:
current time 2026-08-11T16:53:00Z is after 2026-07-26T17:02:54Z
```

## Root cause

The chart default `hubble.tls.auto.method: helm` generates the cert secrets once, then
**reuses whatever secret already exists, regardless of expiry**, on every subsequent
upgrade. From `templates/hubble/tls-helm/server-secret.yaml`:

```gotemplate
{{- with lookup "v1" "Secret" (include "cilium.namespace" .) "hubble-server-certs" }}
  {{- if and (index .data "tls.crt") (index .data "tls.key") }}
    {{- $tls_key = (index .data "tls.key") }}
    {{- $tls_crt = (index .data "tls.crt") }}
  {{- end }}
{{- end }}
```

There is no expiry check, so no Helm upgrade ever renews these. The certs were issued
at install on 2025-07-26 with the default `certValidityDuration: 365`, so they expired
2026-07-26 and every upgrade since has faithfully copied the expired cert forward.

Because Helm waits on `hubble-relay` readiness, this also hard-blocks any Cilium
upgrade, not just Hubble.

| Secret | Subject | Not After |
|---|---|---|
| `cilium-ca` | `CN=Cilium CA` | 2028-07-25 |
| `hubble-server-certs` | `CN=*.pik8s.hubble-grpc.cilium.io` | 2026-07-26 (expired) |
| `hubble-relay-client-certs` | `CN=*.hubble-relay.cilium.io` | 2026-07-26 (expired) |

## Fix

Switch to `hubble.tls.auto.method: cronJob`, the chart's built-in renewal path.
`cilium-certgen` regenerates the leaf certs on the default schedule `0 0 1 */4 *`
(every 4 months, well inside the 365d validity) and a one-shot Job regenerates them
immediately on this upgrade. The existing `cilium-ca` is reused via `--ca-reuse-secret`,
so the CA and trust chain are unchanged.

Chose `cronJob` over `certmanager` because it needs no new issuer resources and no CA
swap - it is one value change against machinery already shipped in the chart.

## Notes

- The two expired secrets are deleted as part of applying this so the certgen Job
  creates them fresh, rather than relying on Helm's post-upgrade deletion of
  now-unmanaged resources racing the Job that recreates them.
- `certgen v0.4.8` is multi-arch (`linux/amd64`, `linux/arm64`), so it runs on both the
  Pi nodes and `thrawn`.
- The agent's `hubble-server-certs` mount is `optional: true`, so agents tolerate the
  brief window where the secrets are absent.