### PR TITLE
fix(bootstrap): pin gateway-api CRDs to v1.6.1

### DIFF
--- a/bootstrap/templates/kubernetes/flux/repositories/git/gateway-api.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/git/gateway-api.yaml.j2
@@ -10,7 +10,7 @@ spec:
   interval: 1h
   url: https://github.com/kubernetes-sigs/gateway-api
   ref:
-    tag: v1.4.1
+    tag: v1.6.1
   ignore: |
     /*
     !/config/crd/experimental


### PR DESCRIPTION
## Problem

`bootstrap/templates/kubernetes/flux/repositories/git/gateway-api.yaml.j2` still pinned
Gateway API `v1.4.1`, while the live `kubernetes/flux/repositories/git/gateway-api.yaml`
has been on `v1.6.1` since ba3a0aa7.

This became a correctness issue with #1310: Cilium 1.20 requires Gateway API v1.6.1 as a
minimum, so bootstrapping a new cluster from these templates would install Cilium 1.20.0
against Gateway API v1.4.1 and fail Cilium's version check.

## Why it drifted

Renovate's `flux` manager file patterns do cover this path, but the file opens with a
jinja guard:

```
#% if bootstrap_cloudflare.enabled %#
```

which makes it unparseable as YAML, so Renovate silently skips it and only ever bumped
the live copy. Worth a follow-up look at whether other `.j2` templates have drifted the
same way - out of scope here.

## Also cleaned up in the cluster (not in this diff)

The `v1.4.1` → `v1.6.1` bump left an orphaned CRD behind, because the gateway-api
Kustomization sets `prune: false`:

```
xlistenersets.gateway.networking.x-k8s.io   v1.4.1   experimental
```

`XListenerSet` graduated out of the experimental `x-k8s.io` group in v1.6.1 and is now
`listenersets.gateway.networking.k8s.io`, so the old CRD is not in v1.6.1's
`config/crd/experimental/kustomization.yaml` and was never updated or removed. It had
zero objects and no repo references, so it was deleted directly. All gateway-api CRDs
now report `v1.6.1` uniformly.